### PR TITLE
change protocol from http to https

### DIFF
--- a/kvvliveapi.py
+++ b/kvvliveapi.py
@@ -14,7 +14,7 @@ import re
 import sys
 
 API_KEY = "377d840e54b59adbe53608ba1aad70e8"
-API_BASE = "http://live.kvv.de/webapp/"
+API_BASE = "https://live.kvv.de/webapp/"
 
 class Stop:
     def __init__(self, name, stop_id, lat, lon):


### PR DESCRIPTION
KVV seems to have destroyed their rewrite rules from http to https
They remove the slash after the TLD, http://kvv.de/webapp becomes https://kvv.dewebapp